### PR TITLE
:lock: Not allow empty info_hash when request scrape page

### DIFF
--- a/scrape.php
+++ b/scrape.php
@@ -7,29 +7,26 @@ dbconn_announce();
 block_browser();
 
 preg_match_all('/info_hash=([^&]*)/i', $_SERVER["QUERY_STRING"], $info_hash_array);
-$fields = "info_hash, times_completed, seeders, leechers";
 
 if (count($info_hash_array[1]) < 1) {
-	$query = "SELECT $fields FROM torrents ORDER BY id";
-}
-else {
-	$query = "SELECT $fields FROM torrents WHERE " . hash_where_arr('info_hash', $info_hash_array[1]);
-}
-$r = "d" . benc_str("files") . "d";
+    err("Empty info_hash is not allowed.");
+} else {
+    $query = "SELECT info_hash, times_completed, seeders, leechers FROM torrents WHERE " . hash_where_arr('info_hash', $info_hash_array[1]);
+    $res = sql_query($query);
 
-$res = sql_query($query);
+    if (mysql_num_rows($res) < 1) {
+        err("Torrent not registered with this tracker.");
+    }
 
-if (mysql_num_rows($res) < 1){
-	err("Torrent not registered with this tracker.");
+    $r = "d" . benc_str("files") . "d";
+    while ($row = mysql_fetch_assoc($res)) {
+        $r .= "20:" . hash_pad($row["info_hash"]) . "d" .
+            benc_str("complete") . "i" . $row["seeders"] . "e" .
+            benc_str("downloaded") . "i" . $row["times_completed"] . "e" .
+            benc_str("incomplete") . "i" . $row["leechers"] . "e" .
+            "e";
+    }
+    $r .= "ee";
+
+    benc_resp_raw($r);
 }
-
-while ($row = mysql_fetch_assoc($res)) {
-	$r .= "20:" . hash_pad($row["info_hash"]) . "d" .
-		benc_str("complete") . "i" . $row["seeders"] . "e" .
-		benc_str("downloaded") . "i" . $row["times_completed"] . "e" .
-		benc_str("incomplete") . "i" . $row["leechers"] . "e" .
-		"e";
-}
-$r .= "ee";
-
-benc_resp_raw($r);


### PR DESCRIPTION
When info_hash is not given in the requests,
The total torrents status (completed, seeders, leechers) of Private Site will be response.
It's not safe and may cause database busy.

In other hand, The [BEP 0048](http://www.bittorrent.org/beps/bep_0048.html) didn't formulate the activity that tracker should do when meet this situation, so A error throwed out is best to protect private tracker.

As this example:
![tim 20180730165317](https://user-images.githubusercontent.com/13842140/43388611-34092dd2-941c-11e8-83a8-9e5234d9d1b2.jpg)
