### PR TITLE
fix(message): 删除短讯箱编辑时 多余的分号

### DIFF
--- a/messages.php
+++ b/messages.php
@@ -560,8 +560,7 @@ if ($action == "editmailboxes2") {
         header("Location: messages.php?action=editmailboxes");
         exit();
     }
-    if ($action2 == "edit") ;
-    {
+    if ($action2 == "edit") {
         $res = sql_query("SELECT * FROM pmboxes WHERE userid=" . sqlesc($CURUSER['id']));
         if (!$res) {
             stderr($lang_messages['std_error'], $lang_messages['text_no_mailboxes_to_edit']);


### PR DESCRIPTION
然而 在我的测试中，这个并没有什么影响。
因为如果用户的行为是`add`，走完前一个分支就`exit();`了，
而如果行为是`edit`，那么都会进入正常的处理流程。
只有当用户行为已定义且不为`edit`时，才可能触发这个隐藏的bug。